### PR TITLE
style issue fixed in ParallaxImage.style.js

### DIFF
--- a/src/parallaximage/ParallaxImage.style.js
+++ b/src/parallaximage/ParallaxImage.style.js
@@ -1,20 +1,20 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-    container: {
-        overflow: 'hidden',
-        alignItems: 'center',
-        justifyContent: 'center'
-    },
-    image: {
-        position: 'relative',
-        resizeMode: 'cover',
-        width: null,
-        height: null
-    },
-    loaderContainer: {
-        ...StyleSheet.absoluteFillObject,
-        alignItems: 'center',
-        justifyContent: 'center'
-    }
+  container: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    overflow: 'hidden',
+  },
+  image: {
+    flex: 1,
+    width: null,
+    height: null
+  },
+  loaderContainer: {
+      ...StyleSheet.absoluteFillObject,
+      alignItems: 'center',
+      justifyContent: 'center'
+  }
 });


### PR DESCRIPTION
### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Tested features checklist
<!--
IMPORTANT: Please make sure that none of these features have been broken by your changes.
It's easy to overlook something you didn't use yet.
-->
- [ ] Default setup ([example](https://github.com/archriss/react-native-snap-carousel/blob/master/example/src/index.js#L46-L87))
- [ ] Carousels with and without momentum enabled ([prop `enableMomentum`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Vertical carousels ([prop `vertical`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] Slide alignment ([prop `activeSlideAlignment`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#style-and-animation))
- [ ] Autoplay ([prop `autoplay`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#autoplay))
- [ ] Loop mode ([prop `loop`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#loop))
- [ ] `ScrollView`/`FlatList` carousels ([prop `useScrollView`](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#behavior))
- [ ] [Callback methods](https://github.com/archriss/react-native-snap-carousel/blob/master/doc/PROPS_METHODS_AND_GETTERS.md#callbacks)
- [ ] [`ParallaxImage` component](https://github.com/archriss/react-native-snap-carousel#parallaximage-component)
- [ ] [`Pagination` component](https://github.com/archriss/react-native-snap-carousel#pagination-component)
- [ ] [Layouts and custom interpolations](https://github.com/archriss/react-native-snap-carousel#layouts-and-custom-interpolations)
